### PR TITLE
Fix breakage when using two words on the menu

### DIFF
--- a/css/component.css
+++ b/css/component.css
@@ -496,6 +496,7 @@ nav a:focus {
 	-webkit-transition: max-width 0.5s;
 	-moz-transition: max-width 0.5s;
 	transition: max-width 0.5s;
+	white-space: nowrap;
 }
 
 .cl-effect-11 a:hover::before,


### PR DESCRIPTION
Hi, how are you?

I was testing the example 11 when I realized that this not work with two words. That's because the words did not fit into the `max-width` before of 100%. 

A simple `white-space: nowrap;` and worked.

Thank you!
